### PR TITLE
Add default value of arguments of triangulate_path_edge

### DIFF
--- a/crates/bermuda/src/lib.rs
+++ b/crates/bermuda/src/lib.rs
@@ -1,9 +1,7 @@
-use numpy::{IntoPyArray, PyArray, PyArray2, PyArrayMethods, PyReadonlyArray2, ToPyArray};
+use numpy::{PyArray, PyArray2, PyArrayMethods, PyReadonlyArray2};
 use pyo3::prelude::*;
 
-use triangulation::{
-    triangulate_path_edge as triangulate_path_edge_rust, PathTriangulation, Point,
-};
+use triangulation::{triangulate_path_edge as triangulate_path_edge_rust, Point};
 
 /// Determines the triangulation of a path in 2D
 ///
@@ -32,6 +30,7 @@ use triangulation::{
 ///     (M-2)x3 array of the indices of the vertices that will form the
 ///     triangles of the triangulation
 #[pyfunction]
+#[pyo3(signature = (path, closed=false, limit=3.0, bevel=false))]
 fn triangulate_path_edge<'py>(
     py: Python<'_>,
     path: PyReadonlyArray2<'_, f32>,

--- a/crates/bermuda/src/lib.rs
+++ b/crates/bermuda/src/lib.rs
@@ -11,12 +11,12 @@ use triangulation::{
 /// ----------
 ///path : np.ndarray
 ///     Nx2 array of central coordinates of path to be triangulated
-/// closed : bool
+/// closed : bool, optional (default=False)
 ///     Bool which determines if the path is closed or not
-/// limit : float
+/// limit : float, optional (default=3.0)
 ///     Miter limit which determines when to switch from a miter join to a
 ///     bevel join
-/// bevel : bool
+/// bevel : bool, optional (default=False)
 ///     Bool which if True causes a bevel join to always be used. If False
 ///     a bevel join will only be used when the miter limit is exceeded
 //

--- a/crates/bermuda/src/lib.rs
+++ b/crates/bermuda/src/lib.rs
@@ -35,9 +35,9 @@ use triangulation::{
 fn triangulate_path_edge<'py>(
     py: Python<'_>,
     path: PyReadonlyArray2<'_, f32>,
-    closed: bool,
-    limit: f32,
-    bevel: bool,
+    closed: Option<bool>,
+    limit: Option<f32>,
+    bevel: Option<bool>,
 ) -> PyResult<(Py<PyArray2<f32>>, Py<PyArray2<f32>>, Py<PyArray2<u32>>)> {
     // Convert the numpy array into a rust compatible representations which is a vector of points.
     let path_: Vec<Point> = path
@@ -51,7 +51,12 @@ fn triangulate_path_edge<'py>(
         .collect();
 
     // Call the re-exported Rust function directly
-    let result = triangulate_path_edge_rust(&path_, closed, limit, bevel);
+    let result = triangulate_path_edge_rust(
+        &path_,
+        closed.unwrap_or(false),
+        limit.unwrap_or(3.0),
+        bevel.unwrap_or(false),
+    );
     let triangle_data: Vec<u32> = result
         .triangles
         .iter()

--- a/tests/test_triangulate.py
+++ b/tests/test_triangulate.py
@@ -187,3 +187,13 @@ def test_default_values_keyword_order():
         closed=True,
     )
     assert len(triangles) == 12
+
+
+def test_change_limit():
+    centers, offsets, triangles = triangulate_path_edge(
+        np.array([[0, 0], [0, 10], [10, 10], [10, 0]], dtype='float32'),
+        bevel=False,
+        closed=True,
+        limit=0.5,
+    )
+    assert len(triangles) == 12

--- a/tests/test_triangulate.py
+++ b/tests/test_triangulate.py
@@ -156,3 +156,34 @@ def test_triangulate_path_edge_py(
     # Verify triangle indices are valid
     assert np.all(triangles >= 0), 'Invalid triangle indices'
     assert np.all(triangles < centers.shape[0]), 'Invalid triangle indices'
+
+
+def test_default_values():
+    centers, offsets, triangles = triangulate_path_edge(
+        np.array([[0, 0], [0, 10], [10, 10], [10, 0]], dtype='float32')
+    )
+    assert len(triangles) == 6
+
+
+def test_default_values_closed():
+    centers, offsets, triangles = triangulate_path_edge(
+        np.array([[0, 0], [0, 10], [10, 10], [10, 0]], dtype='float32'), True
+    )
+    assert len(triangles) == 8
+
+
+def test_default_values_closed_keyword():
+    centers, offsets, triangles = triangulate_path_edge(
+        np.array([[0, 0], [0, 10], [10, 10], [10, 0]], dtype='float32'),
+        closed=True,
+    )
+    assert len(triangles) == 8
+
+
+def test_default_values_keyword_order():
+    centers, offsets, triangles = triangulate_path_edge(
+        np.array([[0, 0], [0, 10], [10, 10], [10, 0]], dtype='float32'),
+        bevel=True,
+        closed=True,
+    )
+    assert len(triangles) == 12


### PR DESCRIPTION
Allow to use `triangulate_path_edge` without providing all arguments 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced `triangulate_path_edge` function to support optional parameters.
	- Improved flexibility for path triangulation method.

- **Tests**
	- Added comprehensive test cases for default parameter handling.
	- Verified triangulation behavior with various input configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->