### PR TITLE
Move orientation to point module

### DIFF
--- a/crates/bermuda/tests/test_point.rs
+++ b/crates/bermuda/tests/test_point.rs
@@ -1,5 +1,5 @@
 use rstest::rstest;
-use triangulation::point::{Point, Segment, Vector};
+use triangulation::point::{orientation, Orientation, Point, Segment, Vector};
 
 #[rstest]
 fn test_segment_order() {
@@ -25,4 +25,47 @@ fn test_vector_add(
         Point::new(x1, y1) + Vector::new(x2, y2),
         Point::new(expected_x, expected_y)
     );
+}
+
+#[rstest]
+#[case::colinear_1(
+    Point::new(0.0, 0.0),
+    Point::new(0.0, 1.0),
+    Point::new(0.0, 2.0),
+    Orientation::Collinear
+)]
+#[case::colinear_2(
+    Point::new(0.0, 0.0),
+    Point::new(0.0, 2.0),
+    Point::new(0.0, 1.0),
+    Orientation::Collinear
+)]
+#[case::colinear_3(
+    Point::new(0.0, 2.0),
+    Point::new(0.0, 0.0),
+    Point::new(0.0, 1.0),
+    Orientation::Collinear
+)]
+#[case::clockwise_1(
+    Point::new(0.0, 0.0),
+    Point::new(0.0, 1.0),
+    Point::new(1.0, 2.0),
+    Orientation::Clockwise
+)]
+#[case::counter_clockwise_1(Point::new(0.0, 0.0), Point::new(0.0, 1.0), Point::new(-1.0, 2.0), Orientation::CounterClockwise)]
+#[case::counter_clockwise_2(
+    Point::new(0.0, 0.0),
+    Point::new(1.0, 0.0),
+    Point::new(1.0, 1.0),
+    Orientation::CounterClockwise
+)] // Right angle
+#[case::colinear_4(Point::new(1.0, 0.0), Point::new(1.0, 1.0), Point::new(1.0, -1.0), Orientation::Collinear)] // Same x, not collinear
+#[case::counter_clockwise_precision(Point::new(0.0, 0.0), Point::new(0.0001, 0.0001), Point::new(-0.0001, 0.0001), Orientation::CounterClockwise)] // Precision case1
+fn test_orientation(
+    #[case] p: Point,
+    #[case] q: Point,
+    #[case] r: Point,
+    #[case] expected: Orientation,
+) {
+    assert_eq!(orientation(p, q, r), expected);
 }

--- a/crates/triangulation/src/point.rs
+++ b/crates/triangulation/src/point.rs
@@ -307,3 +307,55 @@ pub fn vector_length(p1: Point, p2: Point) -> Coord {
     let dy = p1.y - p2.y;
     (dx * dx + dy * dy).sqrt()
 }
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum Orientation {
+    Collinear,
+    Clockwise,
+    CounterClockwise,
+}
+
+/// Determines the orientation of three points (p, q, r).
+///
+/// This function calculates the orientation of the ordered triplet (p, q, r).
+/// The possible return values and their meanings are:
+///
+/// # Arguments
+///
+/// * `p` - The first [`Point`](point::Point).
+/// * `q` - The second [`Point`](point::Point).
+/// * `r` - The third [`Point`](point::Point).
+///
+/// # Returns
+///
+///  Proper Orientation Enum
+///
+/// # Example
+///
+/// ```rust
+/// use triangulation::point::{Point, orientation, Orientation};
+///
+/// let p = Point::new(0.0, 0.0);
+/// let q = Point::new(1.0, 1.0);
+/// let r = Point::new(2.0, 2.0);
+///
+/// assert_eq!(orientation(p, q, r), Orientation::Collinear); // Collinear points
+///
+/// let r_clockwise = Point::new(2.0, 0.0);
+/// assert_eq!(orientation(p, q, r_clockwise), Orientation::Clockwise); // Clockwise orientation
+///
+/// let r_counterclockwise = Point::new(0.0, 2.0);
+/// assert_eq!(orientation(p, q, r_counterclockwise), Orientation::CounterClockwise); // Counterclockwise orientation
+///
+/// ```
+pub fn orientation(p: Point, q: Point, r: Point) -> Orientation {
+    let val1 = (q.y - p.y) * (r.x - q.x);
+    let val2 = (r.y - q.y) * (q.x - p.x);
+    if val1 == val2 {
+        Orientation::Collinear
+    } else if val1 > val2 {
+        Orientation::Clockwise
+    } else {
+        Orientation::CounterClockwise
+    }
+}

--- a/crates/triangulation/src/point.rs
+++ b/crates/triangulation/src/point.rs
@@ -318,7 +318,6 @@ pub enum Orientation {
 /// Determines the orientation of three points (p, q, r).
 ///
 /// This function calculates the orientation of the ordered triplet (p, q, r).
-/// The possible return values and their meanings are:
 ///
 /// # Arguments
 ///
@@ -329,6 +328,11 @@ pub enum Orientation {
 /// # Returns
 ///
 ///  Proper Orientation Enum
+///
+/// # Note
+///
+/// Due to floating-point arithmetic, the results may be sensitive to numerical precision
+/// when points are nearly collinear.
 ///
 /// # Example
 ///
@@ -348,7 +352,7 @@ pub enum Orientation {
 /// assert_eq!(orientation(p, q, r_counterclockwise), Orientation::CounterClockwise); // Counterclockwise orientation
 ///
 /// ```
-pub fn orientation(p: Point, q: Point, r: Point) -> Orientation {
+pub const fn orientation(p: Point, q: Point, r: Point) -> Orientation {
     let val1 = (q.y - p.y) * (r.x - q.x);
     let val2 = (r.y - q.y) * (q.x - p.x);
     if val1 == val2 {


### PR DESCRIPTION
As orientation is used not only in intersection but also in triangulation, let's move it to the point module. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added an `Orientation` enum to represent point orientation in 2D space.
	- Introduced a new `orientation` function to determine the relative position of three points.

- **Tests**
	- Added comprehensive test cases for point orientation scenarios, including collinear, clockwise, and counterclockwise arrangements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->