### PR TITLE
Pin rust toolchain

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include Cargo.toml
+recursive-include rust *.rs
+rust-toolchain.toml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,8 +30,6 @@ dependencies = [
 [tool.setuptools_scm]
 write_to = "python/bermuda/_version.py"
 
-
-
 [tool.setuptools.packages]
 # Pure Python packages/modules
 find = { where = ["python"] }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.84"


### PR DESCRIPTION
To avoid failures of CI because of rust release pin it using `rust-toolchain.toml`