### PR TITLE
Add face triangulation only function

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,23 +9,24 @@ Rust backend for napari contains code to speed up triangulation.
 Currently, this package exports three functions:
 
 * `triangulate_path_edge` – path triangulation
-* `triangulate_polygons_face` – polygon face triangulation  
+* `triangulate_polygons_face` – polygon face triangulation
 * `triangulate_polygons_with_edge` – polygon face and border path triangulation
 
-All functions accept only array data as array of `float32` are supported.     
+All functions accept only array data as array of `float32` are supported.
 
-Below are signatures with docstrings for document API. 
+Below are signatures with docstrings for document API.
 
 ```python
 from typing import Literal
 import numpy as np
 import numpy.typing as npt
 
+
 def triangulate_path_edge(
-    path: npt.NDArray[tuple[int, Literal[2]], np.float32],
-    closed: bool = False,
-    limit: float = 3.0,
-    bevel: bool = False,
+        path: npt.NDArray[tuple[int, Literal[2]], np.float32],
+        closed: bool = False,
+        limit: float = 3.0,
+        bevel: bool = False,
 ) -> tuple[
     npt.NDArray[tuple[int, Literal[2]], np.float32],
     npt.NDArray[tuple[int, Literal[2]], np.float32],
@@ -69,126 +70,125 @@ def triangulate_path_edge(
 
 
 def triangulate_polygons_face(
-    polygons: list[npt.NDArray[tuple[int, int, Literal[2]], np.float32]],
+        polygons: list[npt.NDArray[tuple[int, int, Literal[2]], np.float32]],
 ) -> tuple[
     npt.NDArray[tuple[int, Literal[3]], np.uint32],
     npt.NDArray[tuple[int, Literal[2]], np.float32],
 ]:
-   """Triangulate multiple polygons using a sweeping line algorithm.
-
-   This function performs triangulation of one or more 2D polygons, handling
-   self-intersecting edges and repeated vertices. It returns both the triangulation
-   indices and the vertex coordinates used in the triangulation.
-
-   Parameters
-   ----------
-   polygons : list[numpy.ndarray]
-       List of polygon vertex arrays. Each array should be Nx2 float32 array
-       containing (x, y) coordinates of polygon vertices in counter-clockwise order.
-       The polygons can be non-convex and can contain holes.
-
-   Returns
-   -------
-   triangles : numpy.ndarray
-       Kx3 uint32 array where each row contains three indices defining a triangle
-       in the triangulation. The indices reference points in the returned points array.
-   points : numpy.ndarray
-       Lx2 float32 array containing (x, y) coordinates of vertices used in the
-       triangulation. This includes original vertices and may contain additional points
-       created at polygon intersections.
-
-   Notes
-   -----
-   - The function automatically handles self-intersecting edges by splitting them
-     at intersection points
-   - Duplicate vertices are removed from the output
-   - Input polygons must be oriented counter-clockwise
-   - All coordinates must be finite (no NaN or infinite values)
-   - Zero-area segments should be avoided
-
-   Examples
-   --------
-   >>> # Simple square
-   >>> polygon = np.array([[0, 0], [1, 0], [1, 1], [0, 1]], dtype=np.float32)
-   >>> triangles, points = triangulate_polygons_face([polygon])
-
-   >>> # Multiple polygons
-   >>> poly1 = np.array([[0, 0], [2, 0], [2, 2], [0, 2]], dtype=np.float32)
-   >>> poly2 = np.array([[0.5, 0.5], [1.5, 0.5], [1, 1.5]], dtype=np.float32)
-   >>> triangles, points = triangulate_polygons_face([poly1, poly2])
-   """
-   ...
+    """Triangulate multiple polygons using a sweeping line algorithm.
+ 
+    This function performs triangulation of one or more 2D polygons, handling
+    self-intersecting edges and repeated vertices. It returns both the triangulation
+    indices and the vertex coordinates used in the triangulation.
+ 
+    Parameters
+    ----------
+    polygons : list[numpy.ndarray]
+        List of polygon vertex arrays. Each array should be Nx2 float32 array
+        containing (x, y) coordinates of polygon vertices in counter-clockwise order.
+        The polygons can be non-convex and can contain holes.
+ 
+    Returns
+    -------
+    triangles : numpy.ndarray
+        Kx3 uint32 array where each row contains three indices defining a triangle
+        in the triangulation. The indices reference points in the returned points array.
+    points : numpy.ndarray
+        Lx2 float32 array containing (x, y) coordinates of vertices used in the
+        triangulation. This includes original vertices and may contain additional points
+        created at polygon intersections.
+ 
+    Notes
+    -----
+    - The function automatically handles self-intersecting edges by splitting them
+      at intersection points
+    - Duplicate vertices are removed from the output
+    - Input polygons must be oriented counter-clockwise
+    - All coordinates must be finite (no NaN or infinite values)
+    - Zero-area segments should be avoided
+ 
+    Examples
+    --------
+    >>> # Simple square
+    >>> polygon = np.array([[0, 0], [1, 0], [1, 1], [0, 1]], dtype=np.float32)
+    >>> triangles, points = triangulate_polygons_face([polygon])
+ 
+    >>> # Multiple polygons
+    >>> poly1 = np.array([[0, 0], [2, 0], [2, 2], [0, 2]], dtype=np.float32)
+    >>> poly2 = np.array([[0.5, 0.5], [1.5, 0.5], [1, 1.5]], dtype=np.float32)
+    >>> triangles, points = triangulate_polygons_face([poly1, poly2])
+    """
+    ...
 
 
 def triangulate_polygons_with_edge(
-   polygons: list[npt.NDArray[tuple[int, int, Literal[2]], np.float32]],
+        polygons: list[npt.NDArray[tuple[int, int, Literal[2]], np.float32]],
 ) -> tuple[
-   tuple[
-       npt.NDArray[tuple[int, Literal[2]], np.float32],
-       npt.NDArray[tuple[int, Literal[2]], np.float32],
-       npt.NDArray[tuple[int, Literal[3]], np.uint32],
-   ],
-   tuple[
-       npt.NDArray[tuple[int, Literal[3]], np.uint32],
-       npt.NDArray[tuple[int, Literal[2]], np.float32],
-   ],
+    tuple[
+        npt.NDArray[tuple[int, Literal[2]], np.float32],
+        npt.NDArray[tuple[int, Literal[2]], np.float32],
+        npt.NDArray[tuple[int, Literal[3]], np.uint32],
+    ],
+    tuple[
+        npt.NDArray[tuple[int, Literal[3]], np.uint32],
+        npt.NDArray[tuple[int, Literal[2]], np.float32],
+    ],
 ]:
-   """Triangulate multiple polygons generating both face and edge triangulations.
-   
-   This function performs two types of triangulation:
-   1. Face triangulation of the polygon interiors using a sweeping line algorithm
-   2. Edge triangulation of the polygon boundaries with miter joins
-   
-   Parameters
-   ----------
-   polygons : list[numpy.ndarray]
-      List of polygon vertex arrays. Each array should be Nx2 float32 array
-      containing (x, y) coordinates in counter-clockwise order. The polygons
-      can be non-convex and can contain holes.
-   
-   Returns
-   -------
-   face_triangulation : tuple
-      A tuple containing face triangulation data:
-      - triangles : numpy.ndarray
-          Mx3 uint32 array of vertex indices forming triangles for polygon faces
-      - points : numpy.ndarray
-          Px2 float32 array of vertex coordinates used in face triangulation
-   edge_triangulation : tuple
-      A tuple containing edge triangulation data:
-      - centers : numpy.ndarray
-          Qx2 float32 array of central coordinates for edge triangles
-      - offsets : numpy.ndarray
-          Qx2 float32 array of offset vectors for edge vertices
-      - triangles : numpy.ndarray
-          Rx3 uint32 array of vertex indices for edge triangles
-   
-   Notes
-   -----
-   - Handles self-intersecting edges by splitting them at intersection points
-   - Removes duplicate vertices from the output
-   - Uses fixed parameters for edge triangulation:
-      * Treats polygons as closed
-      * Miter limit = 3.0
-      * Uses miter joins (no beveling)
-   - Input polygons must be oriented counter-clockwise
-   - All coordinates must be finite (no NaN or infinite values)
-   
-   Examples
-   --------
-   >>> # Single square polygon
-   >>> square = np.array([[0, 0], [1, 0], [1, 1], [0, 1]], dtype=np.float32)
-   >>> face_tris, edge_tris = triangulate_polygons_with_edge([square])
-   
-   >>> # Polygon with a hole
-   >>> outer = np.array([[0, 0], [2, 0], [2, 2], [0, 2]], dtype=np.float32)
-   >>> inner = np.array([[0.5, 0.5], [1.5, 0.5], [1, 1.5]], dtype=np.float32)
-   >>> face_tris, edge_tris = triangulate_polygons_with_edge([outer, inner])
-   """
-   ...
+    """Triangulate multiple polygons generating both face and edge triangulations.
+    
+    This function performs two types of triangulation:
+    1. Face triangulation of the polygon interiors using a sweeping line algorithm
+    2. Edge triangulation of the polygon boundaries with miter joins
+    
+    Parameters
+    ----------
+    polygons : list[numpy.ndarray]
+       List of polygon vertex arrays. Each array should be Nx2 float32 array
+       containing (x, y) coordinates in counter-clockwise order. The polygons
+       can be non-convex and can contain holes.
+    
+    Returns
+    -------
+    face_triangulation : tuple
+       A tuple containing face triangulation data:
+       - triangles : numpy.ndarray
+           Mx3 uint32 array of vertex indices forming triangles for polygon faces
+       - points : numpy.ndarray
+           Px2 float32 array of vertex coordinates used in face triangulation
+    edge_triangulation : tuple
+       A tuple containing edge triangulation data:
+       - centers : numpy.ndarray
+           Qx2 float32 array of central coordinates for edge triangles
+       - offsets : numpy.ndarray
+           Qx2 float32 array of offset vectors for edge vertices
+       - triangles : numpy.ndarray
+           Rx3 uint32 array of vertex indices for edge triangles
+    
+    Notes
+    -----
+    - Handles self-intersecting edges by splitting them at intersection points
+    - Removes duplicate vertices from the output
+    - Uses fixed parameters for edge triangulation:
+       * Treats polygons as closed
+       * Miter limit = 3.0
+       * Uses miter joins (no beveling)
+    - Input polygons must be oriented counter-clockwise
+    - All coordinates must be finite (no NaN or infinite values)
+    
+    Examples
+    --------
+    >>> # Single square polygon
+    >>> square = np.array([[0, 0], [1, 0], [1, 1], [0, 1]], dtype=np.float32)
+    >>> face_tris, edge_tris = triangulate_polygons_with_edge([square])
+    
+    >>> # Polygon with a hole
+    >>> outer = np.array([[0, 0], [2, 0], [2, 2], [0, 2]], dtype=np.float32)
+    >>> inner = np.array([[0.5, 0.5], [1.5, 0.5], [1, 1.5]], dtype=np.float32)
+    >>> face_tris, edge_tris = triangulate_polygons_with_edge([outer, inner])
+    """
+    ...
 
 ```
-
 
 ## Development setup
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Currently, this package exports three functions:
 * `triangulate_polygons_face` – polygon face triangulation
 * `triangulate_polygons_with_edge` – polygon face and border path triangulation
 
-All functions accept only array data as array of `float32` are supported.
+All functions accept only numpy arrays with data type `float32`.
 
 Below are signatures with docstrings for document API.
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ def triangulate_path_edge(
 
 
 def triangulate_polygons_face(
-        polygons: list[npt.NDArray[tuple[int, int, Literal[2]], np.float32]],
+        polygons: list[npt.NDArray[tuple[int, Literal[2]], np.float32]],
 ) -> tuple[
     npt.NDArray[tuple[int, Literal[3]], np.uint32],
     npt.NDArray[tuple[int, Literal[2]], np.float32],
@@ -122,7 +122,7 @@ def triangulate_polygons_face(
 
 
 def triangulate_polygons_with_edge(
-        polygons: list[npt.NDArray[tuple[int, int, Literal[2]], np.float32]],
+        polygons: list[npt.NDArray[tuple[int, Literal[2]], np.float32]],
 ) -> tuple[
     tuple[
         npt.NDArray[tuple[int, Literal[2]], np.float32],

--- a/README.md
+++ b/README.md
@@ -6,11 +6,15 @@ Rust backend for napari contains code to speed up triangulation.
 
 ## Usage
 
-Currently, this package exports only one function, `triangulate_path_edge`, which 
-takes a list of points representing a path and returns a list of triangles
-to draw the path with a given width.
+Currently, this package exports three functions:
 
-Currently, only float32 points are supported.
+* `triangulate_path_edge` – path triangulation
+* `triangulate_polygons_face` – polygon face triangulation  
+* `triangulate_polygons_with_edge` – polygon face and border path triangulation
+
+All functions accept only array data as array of `float32` are supported.     
+
+Below are signatures with docstrings for document API. 
 
 ```python
 from typing import Literal
@@ -22,7 +26,11 @@ def triangulate_path_edge(
     closed: bool = False,
     limit: float = 3.0,
     bevel: bool = False,
-) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+) -> tuple[
+    npt.NDArray[tuple[int, Literal[2]], np.float32],
+    npt.NDArray[tuple[int, Literal[2]], np.float32],
+    npt.NDArray[tuple[int, Literal[3]], np.uint32],
+]:
     """Determines the triangulation of a path in 2D.
 
     The resulting `offsets`
@@ -42,7 +50,7 @@ def triangulate_path_edge(
         Miter limit which determines when to switch from a miter join to a
         bevel join
     bevel : bool
-        Bool which if True causes a bevel join to always be used. If False
+        Bool flag to enforce bevel join. If False
         a bevel join will only be used when the miter limit is exceeded
 
     Returns
@@ -58,6 +66,127 @@ def triangulate_path_edge(
         triangles of the triangulation
     """
     ...
+
+
+def triangulate_polygons_face(
+    polygons: list[npt.NDArray[tuple[int, int, Literal[2]], np.float32]],
+) -> tuple[
+    npt.NDArray[tuple[int, Literal[3]], np.uint32],
+    npt.NDArray[tuple[int, Literal[2]], np.float32],
+]:
+   """Triangulate multiple polygons using a sweeping line algorithm.
+
+   This function performs triangulation of one or more 2D polygons, handling
+   self-intersecting edges and repeated vertices. It returns both the triangulation
+   indices and the vertex coordinates used in the triangulation.
+
+   Parameters
+   ----------
+   polygons : list[numpy.ndarray]
+       List of polygon vertex arrays. Each array should be Nx2 float32 array
+       containing (x, y) coordinates of polygon vertices in counter-clockwise order.
+       The polygons can be non-convex and can contain holes.
+
+   Returns
+   -------
+   triangles : numpy.ndarray
+       Kx3 uint32 array where each row contains three indices defining a triangle
+       in the triangulation. The indices reference points in the returned points array.
+   points : numpy.ndarray
+       Lx2 float32 array containing (x, y) coordinates of vertices used in the
+       triangulation. This includes original vertices and may contain additional points
+       created at polygon intersections.
+
+   Notes
+   -----
+   - The function automatically handles self-intersecting edges by splitting them
+     at intersection points
+   - Duplicate vertices are removed from the output
+   - Input polygons must be oriented counter-clockwise
+   - All coordinates must be finite (no NaN or infinite values)
+   - Zero-area segments should be avoided
+
+   Examples
+   --------
+   >>> # Simple square
+   >>> polygon = np.array([[0, 0], [1, 0], [1, 1], [0, 1]], dtype=np.float32)
+   >>> triangles, points = triangulate_polygons_face([polygon])
+
+   >>> # Multiple polygons
+   >>> poly1 = np.array([[0, 0], [2, 0], [2, 2], [0, 2]], dtype=np.float32)
+   >>> poly2 = np.array([[0.5, 0.5], [1.5, 0.5], [1, 1.5]], dtype=np.float32)
+   >>> triangles, points = triangulate_polygons_face([poly1, poly2])
+   """
+   ...
+
+
+def triangulate_polygons_with_edge(
+   polygons: list[npt.NDArray[tuple[int, int, Literal[2]], np.float32]],
+) -> tuple[
+   tuple[
+       npt.NDArray[tuple[int, Literal[2]], np.float32],
+       npt.NDArray[tuple[int, Literal[2]], np.float32],
+       npt.NDArray[tuple[int, Literal[3]], np.uint32],
+   ],
+   tuple[
+       npt.NDArray[tuple[int, Literal[3]], np.uint32],
+       npt.NDArray[tuple[int, Literal[2]], np.float32],
+   ],
+]:
+   """Triangulate multiple polygons generating both face and edge triangulations.
+   
+   This function performs two types of triangulation:
+   1. Face triangulation of the polygon interiors using a sweeping line algorithm
+   2. Edge triangulation of the polygon boundaries with miter joins
+   
+   Parameters
+   ----------
+   polygons : list[numpy.ndarray]
+      List of polygon vertex arrays. Each array should be Nx2 float32 array
+      containing (x, y) coordinates in counter-clockwise order. The polygons
+      can be non-convex and can contain holes.
+   
+   Returns
+   -------
+   face_triangulation : tuple
+      A tuple containing face triangulation data:
+      - triangles : numpy.ndarray
+          Mx3 uint32 array of vertex indices forming triangles for polygon faces
+      - points : numpy.ndarray
+          Px2 float32 array of vertex coordinates used in face triangulation
+   edge_triangulation : tuple
+      A tuple containing edge triangulation data:
+      - centers : numpy.ndarray
+          Qx2 float32 array of central coordinates for edge triangles
+      - offsets : numpy.ndarray
+          Qx2 float32 array of offset vectors for edge vertices
+      - triangles : numpy.ndarray
+          Rx3 uint32 array of vertex indices for edge triangles
+   
+   Notes
+   -----
+   - Handles self-intersecting edges by splitting them at intersection points
+   - Removes duplicate vertices from the output
+   - Uses fixed parameters for edge triangulation:
+      * Treats polygons as closed
+      * Miter limit = 3.0
+      * Uses miter joins (no beveling)
+   - Input polygons must be oriented counter-clockwise
+   - All coordinates must be finite (no NaN or infinite values)
+   
+   Examples
+   --------
+   >>> # Single square polygon
+   >>> square = np.array([[0, 0], [1, 0], [1, 1], [0, 1]], dtype=np.float32)
+   >>> face_tris, edge_tris = triangulate_polygons_with_edge([square])
+   
+   >>> # Polygon with a hole
+   >>> outer = np.array([[0, 0], [2, 0], [2, 2], [0, 2]], dtype=np.float32)
+   >>> inner = np.array([[0.5, 0.5], [1.5, 0.5], [1, 1.5]], dtype=np.float32)
+   >>> face_tris, edge_tris = triangulate_polygons_with_edge([outer, inner])
+   """
+   ...
+
 ```
 
 

--- a/python/bermuda/_bermuda.pyi
+++ b/python/bermuda/_bermuda.pyi
@@ -14,7 +14,7 @@ def triangulate_path_edge(
     npt.NDArray[tuple[int, Literal[3]], np.uint32],
 ]: ...
 def triangulate_polygons_with_edge(
-    polygons: list[npt.NDArray[tuple[int, int, Literal[2]], np.float32]],
+    polygons: list[npt.NDArray[tuple[int, Literal[2]], np.float32]],
 ) -> tuple[
     tuple[
         npt.NDArray[tuple[int, Literal[2]], np.float32],
@@ -27,7 +27,7 @@ def triangulate_polygons_with_edge(
     ],
 ]: ...
 def triangulate_polygons_face(
-    polygons: list[npt.NDArray[tuple[int, int, Literal[2]], np.float32]],
+    polygons: list[npt.NDArray[tuple[int, Literal[2]], np.float32]],
 ) -> tuple[
     npt.NDArray[tuple[int, Literal[3]], np.uint32],
     npt.NDArray[tuple[int, Literal[2]], np.float32],

--- a/python/bermuda/_bermuda.pyi
+++ b/python/bermuda/_bermuda.pyi
@@ -5,9 +5,9 @@ import numpy.typing as npt
 
 def triangulate_path_edge(
     path: npt.NDArray[tuple[int, Literal[2]], np.float32],
-    closed: bool,
-    limit: float,
-    bevel: bool,
+    closed: bool = False,
+    limit: float = 3.0,
+    bevel: bool = False,
 ) -> tuple[
     npt.NDArray[tuple[int, Literal[2]], np.float32],
     npt.NDArray[tuple[int, Literal[2]], np.float32],

--- a/python/bermuda/_bermuda.pyi
+++ b/python/bermuda/_bermuda.pyi
@@ -26,3 +26,9 @@ def triangulate_polygons_with_edge(
         npt.NDArray[tuple[int, Literal[2]], np.float32],
     ],
 ]: ...
+def triangulate_polygons_face(
+    polygons: list[npt.NDArray[tuple[int, int, Literal[2]], np.float32]],
+) -> tuple[
+    npt.NDArray[tuple[int, Literal[3]], np.uint32],
+    npt.NDArray[tuple[int, Literal[2]], np.float32],
+]: ...


### PR DESCRIPTION
Napari also requires an option to triangulate only faces of polygon, so this PR add it by add `triangulate_polygons_face` function 

https://github.com/napari/napari/blob/f5de441ebf47960fa0a626cb1688e143a6412723/napari/layers/shapes/_shapes_models/shape.py#L26-L28

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new face-triangulation capability to handle multiple polygons with enhanced support for irregular shapes.
  - Added a new function for triangulating polygons, expanding the triangulation functionalities available in the package.
- **Refactor**
  - Enhanced polygon data conversion to streamline triangulation processes and improve overall consistency across methods.
- **Documentation**
  - Updated documentation to clarify parameters and return values for existing and new functions, improving user understanding and usability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->