### PR TITLE
Use faster triangulation for convex polygons

### DIFF
--- a/crates/bermuda/src/lib.rs
+++ b/crates/bermuda/src/lib.rs
@@ -195,6 +195,8 @@ fn triangulate_polygons_with_edge(
     // Convert the numpy array into a rust compatible representation which is a vector of points.
     let polygons_ = numpy_polygons_to_rust_polygons(polygons);
     if polygons_.len() == 1 && is_convex(&polygons_[0]) {
+        // if there is only one polygon on list and it is convex
+        // we could use fan triangulation instead of sweeping line
         let face_triangles = triangulate_convex_polygon(&polygons_[0]);
         let path_triangulation = triangulate_paths_edge(&polygons_, true, 3.0, false);
         return Ok((
@@ -248,6 +250,8 @@ fn triangulate_polygons_face(
     let polygons_ = numpy_polygons_to_rust_polygons(polygons);
 
     if polygons_.len() == 1 && is_convex(&polygons_[0]) {
+        // if there is only one polygon on list and it is convex
+        // we could use fan triangulation instead of sweeping line
         let face_triangulation = triangulate_convex_polygon(&polygons_[0]);
         return face_triangulation_to_numpy_arrays(py, &face_triangulation, &polygons_[0]);
     }

--- a/crates/bermuda/src/lib.rs
+++ b/crates/bermuda/src/lib.rs
@@ -4,9 +4,9 @@ use pyo3::prelude::*;
 
 use triangulation::point::Triangle;
 use triangulation::{
-    split_polygons_on_repeated_edges, sweeping_line_triangulation,
-    triangulate_path_edge as triangulate_path_edge_rust, triangulate_paths_edge, PathTriangulation,
-    Point,
+    is_convex, split_polygons_on_repeated_edges, sweeping_line_triangulation,
+    triangulate_convex_polygon, triangulate_path_edge as triangulate_path_edge_rust,
+    triangulate_paths_edge, PathTriangulation, Point,
 };
 
 type EdgeTriangulation = (Py<PyArray2<f32>>, Py<PyArray2<f32>>, Py<PyArray2<u32>>);
@@ -194,6 +194,14 @@ fn triangulate_polygons_with_edge(
 ) -> PyPolygonTriangulation {
     // Convert the numpy array into a rust compatible representation which is a vector of points.
     let polygons_ = numpy_polygons_to_rust_polygons(polygons);
+    if polygons_.len() == 1 && is_convex(&polygons_[0]) {
+        let face_triangles = triangulate_convex_polygon(&polygons_[0]);
+        let path_triangulation = triangulate_paths_edge(&polygons_, true, 3.0, false);
+        return Ok((
+            face_triangulation_to_numpy_arrays(py, &face_triangles, &polygons_[0])?,
+            path_triangulation_to_numpy_arrays(py, &path_triangulation)?,
+        ));
+    }
 
     let (new_polygons, segments) = split_polygons_on_repeated_edges(&polygons_);
     let (face_triangles, face_points) = sweeping_line_triangulation(segments);
@@ -238,6 +246,11 @@ fn triangulate_polygons_face(
 ) -> PyFaceTriangulation {
     // Convert the numpy array into a rust compatible representation which is a vector of points.
     let polygons_ = numpy_polygons_to_rust_polygons(polygons);
+
+    if polygons_.len() == 1 && is_convex(&polygons_[0]) {
+        let face_triangulation = triangulate_convex_polygon(&polygons_[0]);
+        return face_triangulation_to_numpy_arrays(py, &face_triangulation, &polygons_[0]);
+    }
 
     let (_new_polygons, segments) = split_polygons_on_repeated_edges(&polygons_);
     let (face_triangles, face_points) = sweeping_line_triangulation(segments);

--- a/crates/triangulation/src/face_triangulation.rs
+++ b/crates/triangulation/src/face_triangulation.rs
@@ -697,8 +697,12 @@ pub fn sweeping_line_triangulation(edges: Vec<Segment>) -> (Vec<Triangle>, Vec<P
 /// Check if a polygon is convex.
 ///
 /// This function determines if a given polygon is convex by examining its vertices.
-/// A polygon is convex if all its interior angles are less than or equal to 180 degrees
-/// and all vertices have the same orientation.
+/// A polygon is convex if all its interior angles are less than or equal to 180 degrees.
+/// This is determined by checking the orientations of consecutive vertex triplets.
+///
+/// The polygon is considered non-convex if:
+/// - At least one vertex has clockwise orientation while another has counterclockwise orientation
+/// - All vertices are collinear
 ///
 /// # Arguments
 /// * `points` - A slice containing the polygon vertices in order
@@ -781,6 +785,8 @@ where
 {
     let first = iter.next().unwrap();
     let start_angle = f32::atan2(first.y - centroid.y, first.x - centroid.x);
+    // We calculate the angle between starting point, centroid and current point
+    // so we start with 0.0
     let mut prev_angle = 0.0;
 
     for point in iter {

--- a/crates/triangulation/src/face_triangulation.rs
+++ b/crates/triangulation/src/face_triangulation.rs
@@ -766,7 +766,7 @@ pub fn is_convex(points: &[Point]) -> bool {
     }
 }
 
-/// Check if the polygon with all angles having the same orientation does not have self-intersections
+/// Check for a simple polygon where all angles have the same orientation but do not have self-intersections.
 ///
 /// # Arguments
 /// * `begin` - Iterator to the first point of the polygon

--- a/crates/triangulation/src/face_triangulation.rs
+++ b/crates/triangulation/src/face_triangulation.rs
@@ -796,6 +796,14 @@ where
     true
 }
 
+pub fn triangulate_convex_polygon(points: &[Point]) -> Vec<Triangle> {
+    let mut triangles = Vec::new();
+    for i in 1..points.len() - 1 {
+        triangles.push(Triangle::new(0, i as Index, (i + 1) as Index));
+    }
+    triangles
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/triangulation/src/lib.rs
+++ b/crates/triangulation/src/lib.rs
@@ -8,7 +8,9 @@ pub mod monotone_polygon;
 pub mod path_triangulation;
 pub mod point;
 
-pub use crate::face_triangulation::sweeping_line_triangulation;
+pub use crate::face_triangulation::{
+    is_convex, sweeping_line_triangulation, triangulate_convex_polygon,
+};
 pub use crate::intersection::split_polygons_on_repeated_edges;
 pub use crate::path_triangulation::PathTriangulation;
 pub use crate::path_triangulation::{triangulate_path_edge, triangulate_paths_edge};

--- a/crates/triangulation/src/point.rs
+++ b/crates/triangulation/src/point.rs
@@ -505,7 +505,7 @@ pub fn calc_dedup_edges(polygon_list: &[Vec<Point>]) -> Vec<Segment> {
 
 pub fn centroid(points: &[Point]) -> Point {
     if points.is_empty() {
-        panic!("Cannot calculate centroid of empty points list");
+        panic!("Cannot calculate centroid of an empty points list");
     }
     let sum = points.iter().fold(Point::new(0.0, 0.0), |acc, p| {
         Point::new(acc.x + p.x, acc.y + p.y)

--- a/crates/triangulation/src/point.rs
+++ b/crates/triangulation/src/point.rs
@@ -502,3 +502,14 @@ pub fn calc_dedup_edges(polygon_list: &[Vec<Point>]) -> Vec<Segment> {
     }
     edges_set.into_iter().collect()
 }
+
+pub fn centroid(points: &[Point]) -> Point {
+    if points.is_empty() {
+        panic!("Cannot calculate centroid of empty points list");
+    }
+    let sum = points.iter().fold(Point::new(0.0, 0.0), |acc, p| {
+        Point::new(acc.x + p.x, acc.y + p.y)
+    });
+    let n = points.len() as f32;
+    Point::new(sum.x / n, sum.y / n)
+}


### PR DESCRIPTION
Add check if polygon is convex and then uses faster triangulation. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced triangulation for convex polygons, allowing faster and more efficient processing.
  - Introduced a new capability to calculate the centroid of coordinate groups.
  - Expanded the polygon processing toolkit with additional public functionality for improved geometric operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->