### PR TITLE
Add missed metadata to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,6 @@ dynamic = [
     "version",
 ]
 description = "Spatial algorithms for napari project, compiled for performance"
-readme = "README.md"
 requires-python = ">=3.9"
 classifiers = [
     "Development Status :: 3 - Alpha",
@@ -20,12 +19,25 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Scientific/Engineering :: Bio-Informatics",
 ]
 dependencies = [
     "numpy>=1.22.2",
 ]
+
+[project.license]
+text = "BSD 3-Clause"
+
+[project.readme]
+file = "README.md"
+content-type = "text/markdown"
+
+[project.urls]
+"Bug Tracker" = "https://github.com/napari/bermuda/issues"
+Documentation = "https://github.com/napari/bermuda/blob/main/README.md"
+"Source Code" = "https://github.com/napari/bermuda"
 
 [tool.setuptools_scm]
 write_to = "python/bermuda/_version.py"


### PR DESCRIPTION
In main repository we have such metadata on pypi:
![obraz](https://github.com/user-attachments/assets/82057687-dba8-41cc-b8b9-e6f71f4f083d)

Where this project does not have it. 
![obraz](https://github.com/user-attachments/assets/1a64682d-c650-44c9-aa2f-728383539119)

Once we create proper documentation, we should extend it with link to documentation. 
