### PR TITLE
Fix adding obsolete point at the end of path when reconstruct polygons

### DIFF
--- a/crates/bermuda/tests/test_intersection.rs
+++ b/crates/bermuda/tests/test_intersection.rs
@@ -354,3 +354,20 @@ fn test_split_polygon_on_repeated_edges_merge_two_polygons() {
     assert_eq!(polygons.len(), 1);
     assert_eq!(edges.len(), 8);
 }
+
+#[rstest]
+fn test_split_polygons_on_repeated_edges() {
+    let polygon = vec![
+        Point::new(10.97627008, 14.30378733),
+        Point::new(12.05526752, 10.89766366),
+        Point::new(8.47309599, 12.91788226),
+        Point::new(8.75174423, 17.83546002),
+        Point::new(19.27325521, 7.66883038),
+        Point::new(15.83450076, 10.5778984),
+    ];
+
+    let (sub_polygons, edges) =
+        intersection::split_polygons_on_repeated_edges(&vec![polygon.clone()]);
+    assert_eq!(sub_polygons.len(), 1);
+    assert_eq!(sub_polygons[0].len(), 6);
+}

--- a/crates/bermuda/tests/test_path_triangulation.rs
+++ b/crates/bermuda/tests/test_path_triangulation.rs
@@ -1,0 +1,19 @@
+use rstest::rstest;
+
+use triangulation::path_triangulation::triangulate_path_edge;
+use triangulation::point::Point;
+
+#[rstest]
+fn test_path_non_convex_polygon() {
+    let polygon = vec![
+        Point::new(10.97627008, 14.30378733),
+        Point::new(12.05526752, 10.89766366),
+        Point::new(8.47309599, 12.91788226),
+        Point::new(8.75174423, 17.83546002),
+        Point::new(19.27325521, 7.66883038),
+        Point::new(15.83450076, 10.5778984),
+    ];
+    let result = triangulate_path_edge(&polygon, true, 3.0, false);
+    assert_eq!(result.centers.len(), 16);
+    assert_eq!(result.triangles.len(), 14);
+}

--- a/crates/triangulation/src/intersection.rs
+++ b/crates/triangulation/src/intersection.rs
@@ -690,8 +690,8 @@ pub fn split_polygons_on_repeated_edges(
 
             if !current_polygon.is_empty() {
                 // Close the polygon if needed
-                if current_polygon[0] != *current_polygon.last().unwrap() {
-                    current_polygon.push(current_polygon[0]);
+                if current_polygon[0] == *current_polygon.last().unwrap() {
+                    current_polygon.pop();
                 }
                 sub_polygons.push(current_polygon);
                 sub_index += 1;


### PR DESCRIPTION
Fix a bug in `split_polygons_on_repeated_edges` that is adding an obsolete point on the end of the reconstructed path leading on to many triangles being produced. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced polygon closure handling to remove duplicate points, ensuring consistent and accurate shape processing.
  
- **Tests**
  - Added new automated tests to verify reliable splitting of polygons with repeated edges and robust triangulation of non-convex shapes, improving overall stability and dependability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->