### PR TITLE
Fix reconstrucion of polygons from segments

### DIFF
--- a/crates/bermuda/tests/test_intersection.rs
+++ b/crates/bermuda/tests/test_intersection.rs
@@ -366,7 +366,7 @@ fn test_split_polygons_on_repeated_edges() {
         Point::new(15.83450076, 10.5778984),
     ];
 
-    let (sub_polygons, edges) =
+    let (sub_polygons, _edges) =
         intersection::split_polygons_on_repeated_edges(&vec![polygon.clone()]);
     assert_eq!(sub_polygons.len(), 1);
     assert_eq!(sub_polygons[0].len(), 6);


### PR DESCRIPTION
Completely rewrite `split_polygons_on_repeated_edges` to match more PartSegCore C++ implementation and properly reconstruct polygons from list of edges. 

![image](https://github.com/user-attachments/assets/31e30e0a-2837-48db-b0f7-f3754a1bea5c)

When fighting with borrow checker, in previous implementation, I have created code that could visit each point once, not each edge once. 

Somehow I missed it. 

I do not have, good, reproducible test, so I've tested this manually. 