### PR TITLE
Fix workflow for checking for a new rust release

### DIFF
--- a/.github/workflows/check_rust_version.yml
+++ b/.github/workflows/check_rust_version.yml
@@ -40,7 +40,7 @@ jobs:
           # Download the official channel file for stable releases.
           curl -sSL https://static.rust-lang.org/dist/channel-rust-stable.toml -o channel.toml
           # Extract the version (assumes a line like: version = "1.69.0 (abcdef123 2025-02-xx)")
-          LATEST=$(grep '\[pkg.rust\]' -A 5 channel.toml|  grep '^version =' | head -n1 | sed 's/version = "\(.*\)"/\1/' | cut -d' ' -f1)
+          LATEST=$(grep '\[pkg.rust\]' -A 5 channel.toml|  grep -m1 '^version =' | sed 's/version = "\(.*\)"/\1/' | cut -d' ' -f1)
           if [ -z "$LATEST" ]; then
             echo "Could not determine latest stable version"
             exit 1

--- a/.github/workflows/check_rust_version.yml
+++ b/.github/workflows/check_rust_version.yml
@@ -56,6 +56,7 @@ jobs:
           CURRENT_RUST_VERSION: ${{ steps.pinned.outputs.pinned }}
           LATEST_RUST_VERSION: ${{ steps.stable.outputs.stable }}
           TITLE: "[rust check] outdated rust toolchain"
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           filename: .github/OUTDATED_RUST_TEMPLATE.md
           update_existing: true

--- a/.github/workflows/check_rust_version.yml
+++ b/.github/workflows/check_rust_version.yml
@@ -40,7 +40,7 @@ jobs:
           # Download the official channel file for stable releases.
           curl -sSL https://static.rust-lang.org/dist/channel-rust-stable.toml -o channel.toml
           # Extract the version (assumes a line like: version = "1.69.0 (abcdef123 2025-02-xx)")
-          LATEST=$(grep '^version =' channel.toml | head -n1 | sed 's/version = "\(.*\)"/\1/' | cut -d' ' -f1)
+          LATEST=$(grep '\[pkg.rust\]' -A 5 channel.toml|  grep '^version =' | head -n1 | sed 's/version = "\(.*\)"/\1/' | cut -d' ' -f1)
           if [ -z "$LATEST" ]; then
             echo "Could not determine latest stable version"
             exit 1


### PR DESCRIPTION
Add `secrets.GITHUB_TOKEN` to `JasonEtco/create-an-issue` to fix creating issue

add steep for filtering `[pkg.rust]` section to not catch cargo version  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved the accuracy of extracting the latest stable Rust version in the workflow.
  - Enabled authentication for the GitHub action that reports outdated Rust versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->