### PR TITLE
Remove duplicated points in 3d mode, do not crash on colinear polygons 

### DIFF
--- a/crates/bermuda/src/lib.rs
+++ b/crates/bermuda/src/lib.rs
@@ -197,7 +197,7 @@ fn numpy_polygons_to_rust_polygons_3d(
     let polygons_: Vec<Vec<Point>> = polygons
         .into_iter()
         .map(|polygon| {
-            polygon
+            let mut points: Vec<Point> = polygon
                 .as_array()
                 .rows()
                 .into_iter()
@@ -205,7 +205,9 @@ fn numpy_polygons_to_rust_polygons_3d(
                     x: row[pos1],
                     y: row[pos2],
                 })
-                .collect()
+                .collect();
+            points.dedup();
+            points
         })
         .collect();
     (polygons_, drop_axis, drop_value)

--- a/crates/bermuda/src/lib.rs
+++ b/crates/bermuda/src/lib.rs
@@ -153,6 +153,17 @@ fn numpy_polygons_to_rust_polygons(polygons: Vec<PyReadonlyArray2<'_, f32>>) -> 
     polygons_
 }
 
+/// Projects 3D polygons onto a 2D plane by dropping the axis along which all points are collinear.
+///
+/// Determines which coordinate axis is constant across all points in all polygons, then projects each polygon onto the remaining two axes. Consecutive duplicate points are removed from each projected polygon.
+///
+/// # Returns
+/// A tuple containing:
+/// - The projected 2D polygons as vectors of `Point`.
+/// - The index of the dropped axis (0 for x, 1 for y, 2 for z).
+/// - The constant value along the dropped axis.
+///
+/// If the input polygons are not coplanar (i.e., no axis is constant across all points), returns empty polygons, zero for the dropped axis, and zero for the dropped value.
 fn numpy_polygons_to_rust_polygons_3d(
     polygons: Vec<PyReadonlyArray2<'_, f32>>,
 ) -> (Vec<Vec<Point>>, usize, f32) {

--- a/crates/triangulation/src/intersection.rs
+++ b/crates/triangulation/src/intersection.rs
@@ -598,7 +598,7 @@ fn filter_collinear_polygons(
         }
 
         // Check if all triplets of vertices, including the ones that wrap around, are collinear.
-        let are_all_collinear = polygon
+        let are_all_vertices_collinear = polygon
             .windows(3)
             // Check the main body of the polygon
             .all(|w| orientation(w[0], w[1], w[2]) == Orientation::Collinear)
@@ -606,7 +606,7 @@ fn filter_collinear_polygons(
             && orientation(polygon[n - 2], polygon[n - 1], polygon[0]) == Orientation::Collinear
             && orientation(polygon[n - 1], polygon[0], polygon[1]) == Orientation::Collinear;
 
-        are_all_collinear
+        are_all_vertices_collinear
     })
 }
 
@@ -719,7 +719,6 @@ pub fn split_polygons_on_repeated_edges(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::point::calc_dedup_edges;
     use rstest::rstest;
 
     #[rstest]

--- a/crates/triangulation/src/intersection.rs
+++ b/crates/triangulation/src/intersection.rs
@@ -585,6 +585,9 @@ pub fn find_intersection_points(polygon_list: &[Vec<point::Point>]) -> Vec<Vec<p
     new_polygons_list
 }
 
+/// Splits a list of polygons into collinear and non-collinear groups.
+///
+/// Returns a tuple where the first element contains polygons whose consecutive triplets of vertices (including wrap-around triplets) are all collinear, and the second element contains all other polygons.
 fn filter_collinear_polygons(
     polygon_list: &[Vec<point::Point>],
 ) -> (Vec<Vec<point::Point>>, Vec<Vec<point::Point>>) {
@@ -711,4 +714,30 @@ pub fn split_polygons_on_repeated_edges(
     }
     sub_polygons.append(&mut collinear_polygons);
     (sub_polygons, edges_dedup)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::point::calc_dedup_edges;
+    use rstest::rstest;
+
+    #[rstest]
+    fn test_filter_collinear_polygons() {
+        let polygons = vec![
+            vec![
+                point::Point::new(0.0, 0.0),
+                point::Point::new(1.0, 1.0),
+                point::Point::new(2.0, 2.0),
+            ], // collinear
+            vec![
+                point::Point::new(0.0, 0.0),
+                point::Point::new(1.0, 0.0),
+                point::Point::new(1.0, 1.0),
+            ], // not collinear
+        ];
+        let (collinear, normal) = filter_collinear_polygons(&polygons);
+        assert_eq!(collinear.len(), 1);
+        assert_eq!(normal.len(), 1);
+    }
 }


### PR DESCRIPTION
Closes #47

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved polygon processing to remove consecutive duplicate points after projection, ensuring cleaner polygon definitions.
  - Enhanced intersection handling to preserve collinear polygons without unnecessary processing, improving accuracy and performance for specific polygon types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->