### PR TITLE
Improve license information

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "setuptools-rust", "setuptools-scm>=8.1"]
+requires = ["setuptools>=77", "setuptools-rust", "setuptools-scm>=8.1"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -11,7 +11,6 @@ description = "Spatial algorithms for napari project, compiled for performance"
 requires-python = ">=3.9"
 classifiers = [
     "Development Status :: 3 - Alpha",
-    "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
@@ -28,7 +27,7 @@ dependencies = [
 ]
 
 [project.license]
-text = "BSD 3-Clause"
+text = "BSD-3-Clause"
 
 [project.readme]
 file = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,9 +25,7 @@ classifiers = [
 dependencies = [
     "numpy>=1.22.2",
 ]
-
-[project.license]
-text = "BSD-3-Clause"
+license = " BSD-3-Clause"
 
 [project.readme]
 file = "README.md"


### PR DESCRIPTION
Follow the warnings shown when build wheels
```
   /tmp/build-env-ctwve66g/lib/python3.14t/site-packages/setuptools/config/_apply_pyprojecttoml.py:82: SetuptoolsDeprecationWarning: `project.license` as a TOML table is deprecated
  !!
          ********************************************************************************
          Please use a simple string containing a SPDX expression for `project.license`. You can also use `project.license-files`. (Both options available on setuptools>=77.0.0).
          By 2026-Feb-18, you need to update your project and remove deprecated calls
          or your builds will no longer be supported.
          See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
          ********************************************************************************
  !!
```