### PR TITLE
Bump rust toolchain from 1.89 to 1.90

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.89.0"
+channel = "1.90.0"


### PR DESCRIPTION
closes #90 