### PR TITLE
Use uv for setup python

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -50,14 +50,12 @@ jobs:
         python_version: ["3.9", "3.13"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version: ${{ matrix.python_version }}
       - uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7.3.1
         with:
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
           version: "latest"
+          python-version: ${{ matrix.python_version }}
       - name: run test
         run: uv run --group test --no-dev pytest
 


### PR DESCRIPTION
Instead of using `actions/setup-python` and `astral-sh/setup-uv` just use `astral-sh/setup-uv` 