### PR TITLE
Bump cibuildwheel to 4.2.0

### DIFF
--- a/.github/workflows/_build_dist.yml
+++ b/.github/workflows/_build_dist.yml
@@ -29,7 +29,7 @@ jobs:
           cache-on-failure: 'false'
           cache-key: ${{ matrix.os }}-${{ github.event_name }}-${{ github.ref_name }}
       - name: Build wheels
-        uses: pypa/cibuildwheel@4726cd35bb13f7bde50cf2761f2499ac7b3aa32c # v4.1.1
+        uses: pypa/cibuildwheel@1828c10ab37f080699c7b81cea34097c684a7074 # v4.2.0
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           path: ./wheelhouse/*.whl

--- a/.github/workflows/_build_dist.yml
+++ b/.github/workflows/_build_dist.yml
@@ -30,8 +30,9 @@ jobs:
           cache-key: ${{ matrix.os }}-${{ github.event_name }}-${{ github.ref_name }}
       - name: win_arm64 - set environment variables
         if: ${{ matrix.os == 'windows-11-arm' }}
+        shell: pwsh
         run: |
-          echo "C:\Program Files\LLVM\bin" >> $env:GIHUB_PATH
+          echo "C:\Program Files\LLVM\bin" >> $env:GITHUB_PATH
           echo "CC=clang-cl" >> $env:GITHUB_ENV
           echo "CXX=clang-cl" >> $env:GITHUB_ENV
           echo "FC=flang" >> $env:GITHUB_ENV

--- a/.github/workflows/_build_dist.yml
+++ b/.github/workflows/_build_dist.yml
@@ -28,6 +28,13 @@ jobs:
           cache: ${{ inputs.rust_cache }}
           cache-on-failure: 'false'
           cache-key: ${{ matrix.os }}-${{ github.event_name }}-${{ github.ref_name }}
+      - name: win_arm64 - set environment variables
+        if: ${{ matrix.os == 'windows-11-arm' }}
+        run: |
+          echo "C:\Program Files\LLVM\bin" >> $env:GIHUB_PATH
+          echo "CC=clang-cl" >> $env:GITHUB_ENV
+          echo "CXX=clang-cl" >> $env:GITHUB_ENV
+          echo "FC=flang" >> $env:GITHUB_ENV
       - name: Build wheels
         uses: pypa/cibuildwheel@1828c10ab37f080699c7b81cea34097c684a7074 # v4.2.0
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: 3.15",
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Scientific/Engineering :: Bio-Informatics",


### PR DESCRIPTION
Enable build wheel for python 3.15 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Build & Compatibility**
  - Improved Windows ARM64 build support for more reliable package creation.
  - Added Python 3.15 to the list of supported Python versions.
  - Updated the wheel-building tooling for improved build reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->