### PR TITLE
Bump rust to 1.98

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/napari/bermuda.git"
 
 [workspace.dependencies]
 triangulation = { path = "crates/triangulation" }
-pyo3 = { version = "0.29.1", features = ["extension-module"] }
+pyo3 = { version = "0.29.2", features = ["extension-module"] }
 numpy = "0.29.0"
 rstest = "0.26.1"
 

--- a/crates/triangulation/src/path_triangulation.rs
+++ b/crates/triangulation/src/path_triangulation.rs
@@ -45,7 +45,6 @@ fn add_triangles_for_join(
     bevel: bool,
 ) -> f32 {
     let idx = triangles.offsets.len();
-    let mitter: point::Vector;
     let length = point::vector_length(p2, p3);
     let p1_p2_diff_norm = (p2 - p1) / prev_length;
     let p2_p3_diff_norm = (p3 - p2) / length;
@@ -57,8 +56,8 @@ fn add_triangles_for_join(
     triangles.centers.push(p2);
 
     // Check sin_angle to compute mitter vector
-    if sin_angle == 0.0 {
-        mitter = point::Vector::new(p1_p2_diff_norm.y / 2.0, -p1_p2_diff_norm.x / 2.0);
+    let mitter = if sin_angle == 0.0 {
+        point::Vector::new(p1_p2_diff_norm.y / 2.0, -p1_p2_diff_norm.x / 2.0)
     } else {
         let mut scale_factor = 1.0 / sin_angle;
         if bevel || cos_angle < cos_limit {
@@ -66,8 +65,8 @@ fn add_triangles_for_join(
             let (sign, mag) = sign_abs(scale_factor);
             scale_factor = sign * 0.5 * mag.min(prev_length.min(length));
         }
-        mitter = (p1_p2_diff_norm - p2_p3_diff_norm) * scale_factor * 0.5;
-    }
+        (p1_p2_diff_norm - p2_p3_diff_norm) * scale_factor * 0.5
+    };
 
     if bevel || cos_angle < cos_limit {
         triangles.centers.push(p2);

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.97.1"
+channel = "1.98.0"


### PR DESCRIPTION
bump pyo3 to 0.29.2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Maintenance**
  * Updated the Rust toolchain to version 1.98.0.
  * Updated the Python integration dependency to version 0.29.2.
* **Refactor**
  * Simplified internal triangle-join initialization without changing triangulation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->